### PR TITLE
Adjustable polling rate for Accelerometer and Light Sensor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-reterminal",
-  "version": "0.1.4",
+  "version": "0.1.3",
   "description": "The node accessing for Seeed Studio reTerminal various data such as buttons, buzzer, LED, light, touch positions and accelerometer sensor.",
   "main": "index.js",
   "node-red": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "node-red-contrib-reterminal",
-  "version": "0.1.3",
+  "name": "@martinroger/node-red-contrib-reterminal",
+  "version": "0.1.4",
   "description": "The node accessing for Seeed Studio reTerminal various data such as buttons, buzzer, LED, light, touch positions and accelerometer sensor.",
-  "main": "index.js",
   "node-red": {
     "nodes": {
       "reterminal": "reterminal.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "@martinroger/node-red-contrib-reterminal",
+  "name": "node-red-contrib-reterminal",
   "version": "0.1.4",
   "description": "The node accessing for Seeed Studio reTerminal various data such as buttons, buzzer, LED, light, touch positions and accelerometer sensor.",
+  "main": "index.js",
   "node-red": {
     "nodes": {
       "reterminal": "reterminal.js"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/1ft-seabass/node-red-contrib-reterminal.git"
+    "url": "git+https://github.com/martinroger/node-red-contrib-reterminal.git"
   },
   "keywords": [
     "reterminal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-reterminal",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "The node accessing for Seeed Studio reTerminal various data such as buttons, buzzer, LED, light, touch positions and accelerometer sensor.",
   "main": "index.js",
   "node-red": {
@@ -11,7 +11,7 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/martinroger/node-red-contrib-reterminal.git"
+    "url": "git+https://github.com/1ft-seabass/node-red-contrib-reterminal.git"
   },
   "keywords": [
     "reterminal",

--- a/reterminal.html
+++ b/reterminal.html
@@ -32,7 +32,8 @@
       category: 'reTerminal',
       color: '#C7E9C0',
       defaults: {
-          name: { value:"" }
+          name: { value:"" },
+          pollInterval: { value:1000,validate:RED.validators.number()}
       },
       inputs:0,
       outputs:1,
@@ -49,6 +50,10 @@
       <label for="node-input-name"><i class="icon-tag"></i> Name</label>
       <input type="text" id="node-input-name" placeholder="Name">
   </div>
+  <div class="form-row">
+    <label for="node-input-pollInterval"><i class="fa fa-tag"></i> Poll Interval</label>
+     <input type="number" id="node-input-pollInterval">
+ </div>
 </script>
 
 <script type="text/x-red" data-help-name="accelerometer">
@@ -172,7 +177,8 @@
       category: 'reTerminal',
       color: '#C7E9C0',
       defaults: {
-          name: { value:"" }
+          name: { value:"" },
+          pollInterval: { value:1000,validate:RED.validators.number()}
       },
       inputs:0,
       outputs:1,
@@ -189,6 +195,10 @@
       <label for="node-input-name"><i class="icon-tag"></i> Name</label>
       <input type="text" id="node-input-name" placeholder="Name">
   </div>
+  <div class="form-row">
+    <label for="node-input-pollInterval"><i class="fa fa-tag"></i> Poll Interval</label>
+     <input type="number" id="node-input-pollInterval">
+ </div>
 </script>
 
 <script type="text/x-red" data-help-name="light_sensor">
@@ -220,5 +230,5 @@
 </script>
 
 <script type="text/x-red" data-help-name="touch_panel">
-  <p>reTerminal Light Sensor</p>
+  <p>reTerminal Touch Panel</p>
 </script>

--- a/reterminal.js
+++ b/reterminal.js
@@ -71,7 +71,7 @@ module.exports = function (RED) {
     let checkY = false;
     let checkZ = false;
     let currentSendData = JSON.stringify({status:"waiting"});
-    let loopInterval = 1000;
+    let loopInterval = config.pollInterval;
 
     accel.on('A1', function(buffer){
       // console.log('x-axis value=' + buffer);
@@ -227,7 +227,7 @@ module.exports = function (RED) {
     });
     */
 
-    const loopInterval = 1000;
+    const loopInterval = config.pollInterval;
     let timerID = setInterval(
       function () {
         const sensor_value = Number(light.lightSense())


### PR DESCRIPTION
- [X] Accelerometer and Light sensor nodes now feature a polling interval (defaulting at 1000ms) to provide faster/slower inputs.
- [X] Copy-paste typo corrected for the Touch Panel (doesn't do anything but it is cleaner)
- [X] Updated version to 0.1.4 from 0.1.3
- [ ] Surely some work could be done on the validators for Accelerometer and Light Sensor node polling intervals, to prevent 0 and negative values, or floats. A minimum might be settable too, especially for Light Sensor.

Note : faster polling rates mean that on small devices like a RPi, max old elements in memory need to be reduced or things get slower after some time
